### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,12 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",


### PR DESCRIPTION
This PR adds the GitHub Skills activity to the list of available activities at Mergington High School.

## Issue Resolved
Fixes #6

## Changes Made
- Added the GitHub Skills activity to the in-memory database in app.py
- Set the activity description, schedule, max participants, and initialized the participants list

## Testing Done
Verified the activity appears in the application interface and is available for registration.

This addresses the time-sensitive request for the GitHub Skills activity that was announced in the school assembly, as part of the GitHub Certifications program.